### PR TITLE
ENHANCEMENT/FIX: Would sometimes erroneously print ':' to page

### DIFF
--- a/pmpro-download-monitor.php
+++ b/pmpro-download-monitor.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Download Monitor Integration Add On
 Plugin URI: http://www.paidmembershipspro.com/pmpro-download-monitor/
 Description: Require membership for downloads when using the Download Monitor plugin.
-Version: .1
+Version: .2
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, membership, memberships, download monitor, restrict downloads
 Requires at least: 3.5
 Tested up to: 4.4
-Stable tag: .1
+Stable tag: .2
 
 Require membership for downloads when using the Download Monitor plugin.
 
@@ -37,6 +37,8 @@ When using the [download] shortcode you can optionally specify the appropriate "
 If you do not specify a template, the output of the [download] shortcode can be filtered for a non-member by using the filter: pmprodlm_shortcode_download_content_filter. This will alter the message shown to a visitor that is not logged in or a logged in user that doesn't meet membership requirements.
 
 == Changelog ==
+= .2 =
+* ENHANCEMENT/FIX: Would show ':' if membership was required but level was inaccessible (signup allowed = no)
 
 = .1 =
 * Added unique templates for the output of the various download/downloads shortcodes.

--- a/templates/content-download-pmpro.php
+++ b/templates/content-download-pmpro.php
@@ -20,7 +20,7 @@ if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
 				else
 					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
 			?>"><?php echo $dlm_download->get_the_title(); ?></a>
-			<?php _e('Membership Required','pmprodlm'); ?>: <?php echo $download_membership_levels[1]; ?>
+			<?php _e('Membership Required','pmprodlm'); ?><?php echo !empty($download_membership_levels[1]) ? ': ' : null; ?><?php echo $download_membership_levels[1]; ?>
 			<?php	
 		} 
 		else 

--- a/templates/content-download-pmpro_title.php
+++ b/templates/content-download-pmpro_title.php
@@ -21,7 +21,7 @@ if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
 				else
 					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
 			?>"><?php echo $dlm_download->get_the_title(); ?></a>
-			<?php _e('Membership Required','pmprodlm'); ?>: <?php echo $download_membership_levels[1]; ?>
+			<?php _e('Membership Required','pmprodlm'); ?><?php echo !empty($download_membership_levels[1]) ? ': ' : null; ?><?php echo $download_membership_levels[1]; ?>
 			<?php
 		} 
 		else 


### PR DESCRIPTION
ENHANCEMENT/FIX: Would show ':' if membership was required but level was inaccessible ("signup allowed = no")
