### PR TITLE
Bug scrub: Fix DLM filter signature, modernize meta box registration, improve compat

### DIFF
--- a/templates/content-download-pmpro.php
+++ b/templates/content-download-pmpro.php
@@ -15,7 +15,7 @@ if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
 		if ( $dlm_download->exists() ) {
 			?>
 			<a class="download-link" href="<?php 
-				if(count($download_membership_levels) > 1)
+				if(count($download_membership_levels[0]) > 1 || empty($download_membership_levels[0][0]))
 					echo pmpro_url('levels');
 				else
 					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");


### PR DESCRIPTION
## Summary
- **Fix `dlm_can_download` filter callback** to match modern Download Monitor's signature (`$can_download, $download`) instead of the broken (`$download, $version`). The old code was treating the boolean first param as the download object.
- **Modernize meta box registration** using the `pmpro_restrictable_post_types` filter (with REST API class check for PMPro version detection), with legacy `admin_menu` fallback for older PMPro versions.
- **Add `pmprodlm_get_download()` helper** that uses DLM's repository pattern (`download_monitor()->service('download_repository')->retrieve_single()`) instead of direct `new DLM_Download()` instantiation.
- **Add null guard** for deleted membership levels in `pmprodlm_getDownloadLevels` to prevent fatal errors.
- **Handle empty level arrays** when all required levels have signups disabled — now correctly links to the levels page instead of building a broken checkout URL.
- **Use `pmpro_get_no_access_message()`** for PMPro 3.1+ no-access messages for a more consistent experience.
- **Fix template** to use correct `$download_membership_levels[0]` index for the level count check.

## Test plan
- [ ] Restrict a download to a membership level and verify non-members cannot download it
- [ ] Verify non-members see the correct "Membership Required" message with a link to checkout
- [ ] Restrict a download to multiple levels and verify the link goes to the levels page
- [ ] Restrict a download to a level with `allow_signups = false` and verify the levels page link is used
- [ ] Verify the "Require Membership" meta box appears on the dlm_download edit screen in both classic and block editors
- [ ] Test with an older PMPro version to verify the legacy meta box fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)