### PR TITLE
Overhaul template system for membership-restricted downloads

### DIFF
--- a/pmpro-download-monitor.php
+++ b/pmpro-download-monitor.php
@@ -11,8 +11,13 @@
  * License: GPLv2 or later
  */
 
-/*
- * Add Require Membership box to dlm_download CPT
+/**
+ * Add the dlm_download CPT to the list of PMPro restrictable post types.
+ *
+ * @since TBD
+ *
+ * @param array $post_types Array of post types that PMPro can restrict.
+ * @return array Modified array of restrictable post types.
  */
 function pmprodlm_restrictable_post_types( $post_types ) {
 	$post_types[] = 'dlm_download';
@@ -20,7 +25,23 @@ function pmprodlm_restrictable_post_types( $post_types ) {
 }
 add_filter( 'pmpro_restrictable_post_types', 'pmprodlm_restrictable_post_types' );
 
-function pmprodlm_getDownloadLevels($dlm_download) 
+/**
+ * Get the membership level IDs and names required for a download.
+ *
+ * Filters out levels that do not allow signups unless overridden
+ * by the pmpro_membership_content_filter_disallowed_levels filter.
+ *
+ * @since .1
+ *
+ * @param DLM_Download $dlm_download The Download Monitor download object.
+ * @return array {
+ *     Array with two elements.
+ *
+ *     @type int[]  $0 Array of membership level IDs.
+ *     @type string $1 Human-readable level names joined with "or".
+ * }
+ */
+function pmprodlm_getDownloadLevels($dlm_download)
 {
 	$hasaccess = pmpro_has_membership_access($dlm_download->get_id(), NULL, true);
 	if(is_array($hasaccess))
@@ -55,9 +76,18 @@ function pmprodlm_getDownloadLevels($dlm_download)
 	return array($download_membership_levels_ids, $download_membership_levels_names);
 }
 
-/*
- * Require Membership on the Download
-*/
+/**
+ * Check if the current user has membership access to a download.
+ *
+ * Hooked to dlm_can_download to block direct download access
+ * for users without the required membership level.
+ *
+ * @since .1
+ *
+ * @param bool         $can_download Whether the user can download the file.
+ * @param DLM_Download $download     The Download Monitor download object.
+ * @return bool Whether the user can download the file.
+ */
 function pmprodlm_can_download( $can_download, $download ) {
 	if ( !$can_download ) {
 		return $can_download;
@@ -78,6 +108,23 @@ function pmprodlm_can_download( $can_download, $download ) {
 }
 add_filter( 'dlm_can_download', 'pmprodlm_can_download', 10, 2 );
 
+/**
+ * Swap DLM download templates for membership-restricted versions.
+ *
+ * When a download requires membership and the current user does not have access,
+ * this replaces the standard DLM template with a style-matched restricted template.
+ * Supports default, title, box, button, and filename template variants.
+ *
+ * Legacy pmpro_* template names are normalized and trigger a _doing_it_wrong notice.
+ *
+ * @since TBD
+ *
+ * @param string $template The path to the template file.
+ * @param string $slug     The template slug (e.g. 'content-download').
+ * @param string $name     The template name/variant (e.g. 'box', 'button').
+ * @param array  $args     Template arguments including the download object.
+ * @return string The path to the original or restricted template file.
+ */
 function pmprodlm_dlm_get_template_part( $template, $slug, $name, $args = array() ) {
 	// Only handle download content templates, not no-access, tc-form, etc.
 	if ( 'content-download' !== $slug ) {
@@ -112,7 +159,7 @@ function pmprodlm_dlm_get_template_part( $template, $slug, $name, $args = array(
 				esc_html( $name ),
 				esc_html( $suggested )
 			),
-			'.3'
+			'TBD'
 		);
 	}
 
@@ -135,6 +182,17 @@ function pmprodlm_dlm_get_template_part( $template, $slug, $name, $args = array(
 }
 add_filter( 'dlm_get_template_part', 'pmprodlm_dlm_get_template_part', 10, 4 );
 
+/**
+ * Display the PMPro no-access message on the DLM no-access page.
+ *
+ * Shows the appropriate membership required message when a user
+ * is denied access to a download. Uses pmpro_get_no_access_message()
+ * on PMPro 3.1+ and falls back to legacy message handling for older versions.
+ *
+ * @since .1
+ *
+ * @param DLM_Download $download The Download Monitor download object.
+ */
 function pmprodlm_dlm_no_access_after_message($download) {
 	global $current_user;
 	if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
@@ -204,9 +262,15 @@ function pmprodlm_dlm_no_access_after_message($download) {
 }
 add_action('dlm_no_access_after_message', 'pmprodlm_dlm_no_access_after_message', 10, 2);
 
-/*
-Function to add links to the plugin row meta
-*/
+/**
+ * Add documentation and support links to the plugin row meta.
+ *
+ * @since .1
+ *
+ * @param array  $links Array of existing plugin row meta links.
+ * @param string $file  Path to the plugin file relative to the plugins directory.
+ * @return array Modified array of plugin row meta links.
+ */
 function pmprodlm_plugin_row_meta($links, $file) {
 	if(strpos($file, 'pmpro-download-monitor.php') !== false)
 	{

--- a/pmpro-download-monitor.php
+++ b/pmpro-download-monitor.php
@@ -14,22 +14,11 @@
 /*
  * Add Require Membership box to dlm_download CPT
  */
-function pmprodlm_page_meta_wrapper() {
-	add_meta_box( 'pmpro_page_meta', esc_html__( 'Require Membership', 'pmpro-download-monitor' ), 'pmpro_page_meta', 'dlm_download', 'side' );
-}
 function pmprodlm_restrictable_post_types( $post_types ) {
 	$post_types[] = 'dlm_download';
 	return array_unique( $post_types );
 }
-function pmprodlm_cpt_init() {
-	// PMPro versions with this REST route also support the pmpro_restrictable_post_types
-	// filter. Older PMPro versions need the legacy admin_menu metabox fallback.
-	if ( class_exists( 'PMPro_REST_API_Routes' ) && method_exists( 'PMPro_REST_API_Routes', 'pmpro_rest_api_get_post_restrictions' ) )
-		add_filter( 'pmpro_restrictable_post_types', 'pmprodlm_restrictable_post_types' );
-	elseif ( is_admin() )
-		add_action( 'admin_menu', 'pmprodlm_page_meta_wrapper' );
-}
-add_action( "init", "pmprodlm_cpt_init", 20 );
+add_filter( 'pmpro_restrictable_post_types', 'pmprodlm_restrictable_post_types' );
 
 function pmprodlm_getDownloadLevels($dlm_download) 
 {
@@ -89,72 +78,62 @@ function pmprodlm_can_download( $can_download, $download ) {
 }
 add_filter( 'dlm_can_download', 'pmprodlm_can_download', 10, 2 );
 
-function pmprodlm_get_download( $download_id ) {
-	$download_id = intval( $download_id );
-	if ( empty( $download_id ) ) {
-		return false;
+function pmprodlm_dlm_get_template_part( $template, $slug, $name, $args = array() ) {
+	// Only handle download content templates, not no-access, tc-form, etc.
+	if ( 'content-download' !== $slug ) {
+		return $template;
 	}
 
-	if ( function_exists( 'download_monitor' ) ) {
-		try {
-			$dlm_download = download_monitor()->service( 'download_repository' )->retrieve_single( $download_id );
-			if ( !empty( $dlm_download ) && $dlm_download->exists() ) {
-				return $dlm_download;
-			}
-		} catch ( Exception $e ) {
-		}
+	// Only proceed if PMPro is active and we have a download to check.
+	if ( ! function_exists( 'pmpro_hasMembershipLevel' ) ) {
+		return $template;
 	}
 
-	if ( class_exists( 'DLM_Download' ) ) {
-		$dlm_download = new DLM_Download( $download_id );
-		if ( !empty( $dlm_download ) && $dlm_download->exists() ) {
-			return $dlm_download;
-		}
+	// DLM passes the download as either 'dlm_download' or 'download' depending on the caller.
+	$dlm_download = isset( $args['dlm_download'] ) ? $args['dlm_download'] : ( isset( $args['download'] ) ? $args['download'] : null );
+	if ( empty( $dlm_download ) || ! is_object( $dlm_download ) || ! method_exists( $dlm_download, 'get_id' ) ) {
+		return $template;
 	}
 
-	return false;
-}
+	// Normalize name: strip pmpro_ prefix, treat plain 'pmpro' as default.
+	$variant = str_replace( 'pmpro_', '', $name );
+	if ( 'pmpro' === $variant ) {
+		$variant = '';
+	}
 
-function pmprodlm_dlm_get_template_part( $template, $slug, $name ) {	
-	if($name == 'pmpro')
-	{
-		$template = trailingslashit( dirname(__FILE__) ) . "templates/content-download-pmpro.php";
+	// Flag misuse of internal pmpro_ template names in shortcode/block attributes.
+	if ( $name !== $variant ) {
+		$suggested = ! empty( $variant ) ? 'template="' . $variant . '"' : 'the default template';
+		_doing_it_wrong(
+			'[download] template attribute',
+			sprintf(
+				/* translators: 1: old template name, 2: suggested replacement */
+				esc_html__( 'The "%1$s" template should no longer be used directly. Use %2$s instead.', 'pmpro-download-monitor' ),
+				esc_html( $name ),
+				esc_html( $suggested )
+			),
+			'.3'
+		);
 	}
-	elseif(strpos($name, "pmpro_") !== false)
-	{
-		$template = trailingslashit( dirname(__FILE__) ) . "templates/content-download-" . $name . ".php";
+
+	// If user has access, return the DLM template unchanged.
+	if ( pmpro_has_membership_access( $dlm_download->get_id() ) ) {
+		return $template;
 	}
+
+	// User doesn't have access. Swap to a style-matched restricted template.
+	$pmpro_templates_dir = trailingslashit( dirname( __FILE__ ) ) . 'templates/';
+
+	// Look for a style-matched restricted template, fall back to default.
+	if ( ! empty( $variant ) && file_exists( $pmpro_templates_dir . 'content-download-pmpro_' . $variant . '.php' ) ) {
+		$template = $pmpro_templates_dir . 'content-download-pmpro_' . $variant . '.php';
+	} else {
+		$template = $pmpro_templates_dir . 'content-download-pmpro.php';
+	}
+
 	return $template;
 }
-add_filter('dlm_get_template_part', 'pmprodlm_dlm_get_template_part', 10, 3);
-
-function pmprodlm_shortcode_download_content( $content, $download_id, $atts ) {
-	global $current_user;
-	if(empty($atts['template']) && (function_exists( 'pmpro_hasMembershipLevel' )) ) {
-		if ( !pmpro_has_membership_access( $download_id ) )
-		{
-			$dlm_download = pmprodlm_get_download( $download_id );
-			if ( !empty( $dlm_download ) && $dlm_download->exists() )
-			{
-				$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
-				$content .= '<a href="';
-				if(count($download_membership_levels[0]) > 1 || empty($download_membership_levels[0][0]))
-					$content .= esc_url( pmpro_url('levels') );
-				else
-					$content .= esc_url( pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https") );
-				$content .= '">' . esc_html( $dlm_download->get_the_title() ) . '</a>';
-				$content .= ' (' . esc_html__( 'Membership Required', 'pmpro-download-monitor' ) . ': ' . esc_html( $download_membership_levels[1] ) . ')';
-				$content = apply_filters("pmprodlm_shortcode_download_content_filter", $content);
-			} 
-			else 
-			{
-				$content = '[' . esc_html__( 'Download not found', 'pmpro-download-monitor' ) . ']';
-			}
-		}
-	}
-	return $content;
-}
-add_filter('dlm_shortcode_download_content', 'pmprodlm_shortcode_download_content', 10, 3);
+add_filter( 'dlm_get_template_part', 'pmprodlm_dlm_get_template_part', 10, 4 );
 
 function pmprodlm_dlm_no_access_after_message($download) {
 	global $current_user;

--- a/readme.txt
+++ b/readme.txt
@@ -14,8 +14,6 @@ Require membership for downloads when using the Download Monitor plugin.
 
 The Download Monitor Integration Add On for Paid Memberships Pro adds a "Require Membership" meta box to the "Edit Download" page, allowing you to easily toggle the membership level(s) that can access the download.
 
-When using the [download] shortcode, you can now use the templates: "pmpro", "pmpro_box", "pmpro_button", "pmpro_filename", "pmpro_title" to show the non-member a link to the membership levels page and a list of the levels that are required to download the file.
-
 Requires Download Monitor (https://wordpress.org/plugins/download-monitor/) and Paid Memberships Pro installed and activated.
 
 == Official Paid Memberships Pro Add On ==
@@ -38,10 +36,6 @@ This is an official Add On for [Paid Memberships Pro](https://www.paidmembership
 1. After activation, navigate to "Downloads" to Edit or Add a New Download.
 1. Check the box for each level that can access this download in the "Require Membership" meta box (below the Publish box in the right sidebar). 
 1. Save your changes by clicking the "Update" button (or "Publish" if you are creating a new download).
-
-When using the [download] shortcode you can optionally specify the appropriate "pmpro" template. Available templates include: "pmpro", "pmpro_box", "pmpro_button", "pmpro_filename", "pmpro_title".
-
-If you do not specify a template, the output of the [download] shortcode can be filtered for a non-member by using the filter: pmprodlm_shortcode_download_content_filter. This will alter the message shown to a visitor that is not logged in or a logged in user that doesn't meet membership requirements.
 
 == Changelog ==
 = .2.1 =

--- a/templates/content-download-pmpro.php
+++ b/templates/content-download-pmpro.php
@@ -1,44 +1,72 @@
 <?php
 /**
- * PMPro custom template output for a download via the [download] shortcode
+ * Restricted download output (default style).
+ *
+ * Shown when the current user does not have membership access to the download.
+ * Matches the structure of Download Monitor's content-download.php template.
+ *
+ * @version .3
+ *
+ * @var DLM_Download       $dlm_download   The download object.
+ * @var Attributes         $dlm_attributes The shortcode attributes.
+ * @var TemplateAttributes $attributes     The template attributes.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
-global $current_user;
-if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
-	if ( !pmpro_has_membership_access( $dlm_download->get_id() ) ) 
-	{
-		$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
-	
-		if ( $dlm_download->exists() ) {
-			?>
-			<a class="download-link" href="<?php
-				if(count($download_membership_levels[0]) > 1 || empty($download_membership_levels[0][0]))
-					echo esc_url( pmpro_url('levels') );
-				else
-					echo esc_url( pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https") );
-			?>"><?php echo esc_html( $dlm_download->get_the_title() ); ?></a>
-			<?php esc_html_e( 'Membership Required', 'pmpro-download-monitor' ); ?><?php echo !empty($download_membership_levels[1]) ? ': ' : null; ?><?php echo esc_html( $download_membership_levels[1] ); ?>
-			<?php	
-		} 
-		else 
-		{
-			?>
-			[<?php esc_html_e( 'Download not found', 'pmpro-download-monitor' ); ?>]
-			<?php
-		}
-	}
-	else
-	{
-		?>
-		<a class="download-link" title="<?php if ( $dlm_download->has_version_number() ) {
-		printf( esc_attr__( 'Version %s', 'download-monitor' ), esc_attr( $dlm_download->get_the_version_number() ) );
-		} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-		<?php $dlm_download->the_title(); ?>
-		(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>)
-		</a>
-		<?php
-	}
+
+if ( ! isset( $dlm_download ) || ! $dlm_download ) {
+	return esc_html__( 'No download found', 'download-monitor' );
 }
+
+// Assign the template to a variable for easier access.
+$template = __FILE__;
+
+// This is a fix for the Gutenberg block to ensure the added classes are loaded.
+if ( ! empty( $dlm_attributes['className'] ) ) {
+	$attributes['link_attributes']['class'][] = $dlm_attributes['className'];
+}
+
+// Get the required membership levels and override the link.
+$download_membership_levels = pmprodlm_getDownloadLevels( $dlm_download );
+if ( count( $download_membership_levels[0] ) > 1 || empty( $download_membership_levels[0][0] ) ) {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'levels' ) );
+} else {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'checkout', '?level=' . $download_membership_levels[0][0], 'https' ) );
+}
+unset( $attributes['link_attributes']['rel'] );
+
+/**
+ * Hook: dlm_template_content_before_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_before_link', $dlm_download, $attributes, $template );
+?>
+<a <?php echo DLM_Utils::generate_attributes( $attributes['link_attributes'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<?php $dlm_download->the_title(); ?>
+</a>
+(<?php
+	echo esc_html__( 'Membership Required', 'pmpro-download-monitor' );
+	if ( ! empty( $download_membership_levels[1] ) ) {
+		echo ': ' . esc_html( $download_membership_levels[1] );
+	}
+?>)
+<?php
+
+/**
+ * Hook: dlm_template_content_after_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_after_link', $dlm_download, $attributes, $template );
+?>

--- a/templates/content-download-pmpro.php
+++ b/templates/content-download-pmpro.php
@@ -5,7 +5,7 @@
  * Shown when the current user does not have membership access to the download.
  * Matches the structure of Download Monitor's content-download.php template.
  *
- * @version .3
+ * @version TBD
  *
  * @var DLM_Download       $dlm_download   The download object.
  * @var Attributes         $dlm_attributes The shortcode attributes.

--- a/templates/content-download-pmpro_box.php
+++ b/templates/content-download-pmpro_box.php
@@ -5,7 +5,7 @@
  * Shown when the current user does not have membership access to the download.
  * Matches the structure of Download Monitor's content-download-box.php template.
  *
- * @version .3
+ * @version TBD
  *
  * @var DLM_Download       $dlm_download   The download object.
  * @var Attributes         $dlm_attributes The shortcode attributes.

--- a/templates/content-download-pmpro_box.php
+++ b/templates/content-download-pmpro_box.php
@@ -1,73 +1,89 @@
 <?php
 /**
- * PMPro custom template output for a download via the [download] shortcode
+ * Restricted download output (box style).
+ *
+ * Shown when the current user does not have membership access to the download.
+ * Matches the structure of Download Monitor's content-download-box.php template.
+ *
+ * @version .3
+ *
+ * @var DLM_Download       $dlm_download   The download object.
+ * @var Attributes         $dlm_attributes The shortcode attributes.
+ * @var TemplateAttributes $attributes     The template attributes.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
-global $current_user;
-if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
-	if ( !pmpro_has_membership_access( $dlm_download->get_id() ) ) 
-	{
-		$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
 
-		if ( $dlm_download->exists() ) {
-			?>
-			<aside class="download-box">
-				<?php $dlm_download->the_image(); ?>	
-				<div
-					class="download-count"><?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?></div>
-			
-				<div class="download-box-content">
-			
-					<h1><?php $dlm_download->the_title(); ?></h1>
-			
-					<?php $dlm_download->the_short_description(); ?>
-			
-					<a class="download-button" href="<?php 
-						if(count($download_membership_levels[0]) > 1)
-							echo pmpro_url('levels');
-						else
-							echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
-					?>">
-						<?php _e('Membership Required','pmprodlm'); ?>
-						<small><?php echo $download_membership_levels[1]; ?></small>
-					</a>
-				</div>
-			</aside>
-			<?php	
-		} 
-		else 
-		{
-			?>
-			[<?php _e( 'Download not found', 'download-monitor' ); ?>]
-			<?php
-		}
-	}
-	else
-	{
-		?>
-		<aside class="download-box">
-			<?php $dlm_download->the_image(); ?>	
-			<div
-				class="download-count"><?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?></div>
-		
-			<div class="download-box-content">
-		
-				<h1><?php $dlm_download->the_title(); ?></h1>
-		
-				<?php $dlm_download->the_short_description(); ?>
-		
-				<a class="download-button" title="<?php if ( $dlm_download->has_version_number() ) {
-					printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_the_version_number() );
-				} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-					<?php _e( 'Download File', 'download-monitor' ); ?>
-					<small><?php $dlm_download->the_filename(); ?> &ndash; <?php $dlm_download->the_filesize(); ?></small>
-				</a>
-		
-			</div>
-		</aside>
-		<?php
-	}
+if ( ! isset( $dlm_download ) || ! $dlm_download ) {
+	return esc_html__( 'No download found', 'download-monitor' );
 }
+
+// Assign the template to a variable for easier access.
+$template = __FILE__;
+
+// This is a fix for the Gutenberg block to ensure the added classes are loaded.
+if ( ! empty( $dlm_attributes['className'] ) ) {
+	$attributes['link_attributes']['class'][] = $dlm_attributes['className'];
+}
+
+// Get the required membership levels and override the link.
+$download_membership_levels = pmprodlm_getDownloadLevels( $dlm_download );
+if ( count( $download_membership_levels[0] ) > 1 || empty( $download_membership_levels[0][0] ) ) {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'levels' ) );
+} else {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'checkout', '?level=' . $download_membership_levels[0][0], 'https' ) );
+}
+unset( $attributes['link_attributes']['rel'] );
+?>
+<aside
+	class="download-box<?php
+	echo ( ! empty( $dlm_attributes['className'] ) ) ? ' ' . esc_attr( $dlm_attributes['className'] ) : ''; ?>">
+
+	<?php $dlm_download->the_image(); ?>
+
+	<div
+		class="download-count"><?php
+		printf( esc_html( _n( '1 download', '%d downloads', $dlm_download->get_download_count(), 'download-monitor' ) ), esc_html( $dlm_download->get_download_count() ) ); ?></div>
+
+	<div
+		class="download-box-content">
+
+		<h1><?php $dlm_download->the_title(); ?></h1>
+
+		<?php $dlm_download->the_excerpt(); ?>
+		<?php
+
+		/**
+		 * Hook: dlm_template_content_before_link.
+		 *
+		 * @param DLM_Download $dlm_download The download object.
+		 * @param array        $attributes   The template attributes.
+		 * @param string       $template     The template file.
+		 *
+		 * @since 4.9.6
+		 */
+		do_action( 'dlm_template_content_before_link', $dlm_download, $attributes, $template );
+		?>
+		<a <?php echo DLM_Utils::generate_attributes( $attributes['link_attributes'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+			<?php echo esc_html__( 'Membership Required', 'pmpro-download-monitor' ); ?>
+			<?php if ( ! empty( $download_membership_levels[1] ) ) { ?>
+				<small><?php echo esc_html( $download_membership_levels[1] ); ?></small>
+			<?php } ?>
+		</a>
+		<?php
+
+		/**
+		 * Hook: dlm_template_content_after_link.
+		 *
+		 * @param DLM_Download $dlm_download The download object.
+		 * @param array        $attributes   The template attributes.
+		 * @param string       $template     The template file.
+		 *
+		 * @since 4.9.6
+		 */
+		do_action( 'dlm_template_content_after_link', $dlm_download, $attributes, $template );
+		?>
+	</div>
+</aside>

--- a/templates/content-download-pmpro_button.php
+++ b/templates/content-download-pmpro_button.php
@@ -5,7 +5,7 @@
  * Shown when the current user does not have membership access to the download.
  * Matches the structure of Download Monitor's content-download-button.php template.
  *
- * @version .3
+ * @version TBD
  *
  * @var DLM_Download       $dlm_download   The download object.
  * @var Attributes         $dlm_attributes The shortcode attributes.

--- a/templates/content-download-pmpro_button.php
+++ b/templates/content-download-pmpro_button.php
@@ -1,44 +1,73 @@
 <?php
 /**
- * PMPro custom template output for a download via the [download] shortcode
+ * Restricted download output (button style).
+ *
+ * Shown when the current user does not have membership access to the download.
+ * Matches the structure of Download Monitor's content-download-button.php template.
+ *
+ * @version .3
+ *
+ * @var DLM_Download       $dlm_download   The download object.
+ * @var Attributes         $dlm_attributes The shortcode attributes.
+ * @var TemplateAttributes $attributes     The template attributes.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
-global $current_user;
-if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
-	if ( !pmpro_has_membership_access( $dlm_download->get_id() ) ) 
-	{
-		$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
-		
-		if ( $dlm_download->exists() ) {
-			?>
-			<p><a class="aligncenter download-button" href="<?php 
-				if(count($download_membership_levels[0]) > 1)
-					echo pmpro_url('levels');
-				else
-					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
-			?>">
-				<?php printf( __( 'Download &ldquo;%s&rdquo;', 'download-monitor' ), $dlm_download->get_the_title() ); ?>
-				<small><?php _e('Membership Required','pmprodlm'); ?>: <?php echo $download_membership_levels[1]; ?></small>
-			</a></p>
-			<?php	
-		} 
-		else 
-		{
-			?>
-			[<?php _e( 'Download not found', 'download-monitor' ); ?>]
-			<?php
-		}
-	}
-	else
-	{
-		?>
-		<p><a class="aligncenter download-button" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-			<?php printf( __( 'Download &ldquo;%s&rdquo;', 'download-monitor' ), $dlm_download->get_the_title() ); ?>
-			<small><?php $dlm_download->the_filename(); ?> &ndash; <?php printf( _n( 'Downloaded 1 time', 'Downloaded %d times', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?> &ndash; <?php $dlm_download->the_filesize(); ?></small>
-		</a></p>
-		<?php
-	}
+
+if ( ! isset( $dlm_download ) || ! $dlm_download ) {
+	return esc_html__( 'No download found', 'download-monitor' );
 }
+
+// Assign the template to a variable for easier access.
+$template = __FILE__;
+
+// This is a fix for the Gutenberg block to ensure the added classes are loaded.
+if ( ! empty( $dlm_attributes['className'] ) ) {
+	$attributes['link_attributes']['class'][] = $dlm_attributes['className'];
+}
+
+// Get the required membership levels and override the link.
+$download_membership_levels = pmprodlm_getDownloadLevels( $dlm_download );
+if ( count( $download_membership_levels[0] ) > 1 || empty( $download_membership_levels[0][0] ) ) {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'levels' ) );
+} else {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'checkout', '?level=' . $download_membership_levels[0][0], 'https' ) );
+}
+unset( $attributes['link_attributes']['rel'] );
+
+/**
+ * Hook: dlm_template_content_before_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_before_link', $dlm_download, $attributes, $template );
+?>
+
+<a <?php echo DLM_Utils::generate_attributes( $attributes['link_attributes'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<?php printf( esc_html__( 'Download &ldquo;%s&rdquo;', 'download-monitor' ), wp_kses_post( $dlm_download->get_title() ) ); ?>
+	<small><?php
+		echo esc_html__( 'Membership Required', 'pmpro-download-monitor' );
+		if ( ! empty( $download_membership_levels[1] ) ) {
+			echo ': ' . esc_html( $download_membership_levels[1] );
+		}
+	?></small>
+</a>
+<?php
+
+/**
+ * Hook: dlm_template_content_after_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_after_link', $dlm_download, $attributes, $template );
+?>

--- a/templates/content-download-pmpro_filename.php
+++ b/templates/content-download-pmpro_filename.php
@@ -5,7 +5,7 @@
  * Shown when the current user does not have membership access to the download.
  * Matches the structure of Download Monitor's content-download-filename.php template.
  *
- * @version .3
+ * @version TBD
  *
  * @var DLM_Download       $dlm_download   The download object.
  * @var Attributes         $dlm_attributes The shortcode attributes.

--- a/templates/content-download-pmpro_filename.php
+++ b/templates/content-download-pmpro_filename.php
@@ -1,45 +1,72 @@
 <?php
 /**
- * PMPro custom template output for a download via the [download] shortcode
+ * Restricted download output (filename style).
+ *
+ * Shown when the current user does not have membership access to the download.
+ * Matches the structure of Download Monitor's content-download-filename.php template.
+ *
+ * @version .3
+ *
+ * @var DLM_Download       $dlm_download   The download object.
+ * @var Attributes         $dlm_attributes The shortcode attributes.
+ * @var TemplateAttributes $attributes     The template attributes.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
-global $current_user;
-if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {	
-	if ( !pmpro_has_membership_access( $dlm_download->get_id() ) ) 
-	{
-		$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
-		
-		if ( $dlm_download->exists() ) {
-			?>
-			<a class="download-link filetype-icon <?php echo 'filetype-' . $dlm_download->get_the_filetype(); ?>" href="<?php 
-				if(count($download_membership_levels[0]) > 1)
-					echo pmpro_url('levels');
-				else
-					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
-			?>"><?php $dlm_download->the_filename(); ?></a> 
-			<?php _e('Membership Required','pmprodlm'); ?>: <?php echo $download_membership_levels[1]; ?>
-			<?php	
-		} 
-		else 
-		{
-			?>
-			[<?php _e( 'Download not found', 'download-monitor' ); ?>]
-			<?php
-		}
-	}
-	else
-	{
-		?>
-		<a class="download-link filetype-icon <?php echo 'filetype-' . $dlm_download->get_the_filetype(); ?>"
-		   title="<?php if ( $dlm_download->has_version_number() ) {
-			   printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_the_version_number() );
-		   } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-			<?php $dlm_download->the_filename(); ?>
-			(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>)
-		</a>
-		<?php
-	}
+
+if ( ! isset( $dlm_download ) || ! $dlm_download ) {
+	return esc_html__( 'No download found', 'download-monitor' );
 }
+
+// Assign the template to a variable for easier access.
+$template = __FILE__;
+
+// This is a fix for the Gutenberg block to ensure the added classes are loaded.
+if ( ! empty( $dlm_attributes['className'] ) ) {
+	$attributes['link_attributes']['class'][] = $dlm_attributes['className'];
+}
+
+// Get the required membership levels and override the link.
+$download_membership_levels = pmprodlm_getDownloadLevels( $dlm_download );
+if ( count( $download_membership_levels[0] ) > 1 || empty( $download_membership_levels[0][0] ) ) {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'levels' ) );
+} else {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'checkout', '?level=' . $download_membership_levels[0][0], 'https' ) );
+}
+unset( $attributes['link_attributes']['rel'] );
+
+/**
+ * Hook: dlm_template_content_before_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_before_link', $dlm_download, $attributes, $template );
+?>
+<a <?php echo DLM_Utils::generate_attributes( $attributes['link_attributes'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<?php echo esc_html( $dlm_download->get_version()->get_filename() ); ?>
+</a>
+(<?php
+	echo esc_html__( 'Membership Required', 'pmpro-download-monitor' );
+	if ( ! empty( $download_membership_levels[1] ) ) {
+		echo ': ' . esc_html( $download_membership_levels[1] );
+	}
+?>)
+<?php
+
+/**
+ * Hook: dlm_template_content_after_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_after_link', $dlm_download, $attributes, $template );
+?>

--- a/templates/content-download-pmpro_title.php
+++ b/templates/content-download-pmpro_title.php
@@ -5,7 +5,7 @@
  * Shown when the current user does not have membership access to the download.
  * Matches the structure of Download Monitor's content-download-title.php template.
  *
- * @version .3
+ * @version TBD
  *
  * @var DLM_Download       $dlm_download   The download object.
  * @var Attributes         $dlm_attributes The shortcode attributes.

--- a/templates/content-download-pmpro_title.php
+++ b/templates/content-download-pmpro_title.php
@@ -1,44 +1,72 @@
 <?php
 /**
- * PMPro custom template output for a download via the [download] shortcode
+ * Restricted download output (title style).
+ *
+ * Shown when the current user does not have membership access to the download.
+ * Matches the structure of Download Monitor's content-download-title.php template.
+ *
+ * @version .3
+ *
+ * @var DLM_Download       $dlm_download   The download object.
+ * @var Attributes         $dlm_attributes The shortcode attributes.
+ * @var TemplateAttributes $attributes     The template attributes.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
-global $current_user;
-if ( function_exists( 'pmpro_hasMembershipLevel' ) ) {
-	if ( !pmpro_has_membership_access( $dlm_download->get_id() ) ) 
-	{
-		$download_membership_levels = pmprodlm_getDownloadLevels($dlm_download);
-		
-		if ( $dlm_download->exists() ) {
-			?>
-			<a class="download-link" href="
-			<?php 
-				if(count($download_membership_levels[0]) > 1)
-					echo pmpro_url('levels');
-				else
-					echo pmpro_url("checkout", "?level=" . $download_membership_levels[0][0], "https");
-			?>"><?php echo $dlm_download->get_the_title(); ?></a>
-			<?php _e('Membership Required','pmprodlm'); ?><?php echo !empty($download_membership_levels[1]) ? ': ' : null; ?><?php echo $download_membership_levels[1]; ?>
-			<?php
-		} 
-		else 
-		{
-			?>
-			[<?php _e( 'Download not found', 'download-monitor' ); ?>]
-			<?php
-		}
-	}
-	else
-	{
-		?>
-		<a class="download-link" title="<?php if ( $dlm_download->has_version_number() ) {
-			printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_the_version_number() );
-		} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-			<?php $dlm_download->the_title(); ?>
-		</a>
-		<?php
-	}
+
+if ( ! isset( $dlm_download ) || ! $dlm_download ) {
+	return esc_html__( 'No download found', 'download-monitor' );
 }
+
+// Assign the template to a variable for easier access.
+$template = __FILE__;
+
+// This is a fix for the Gutenberg block to ensure the added classes are loaded.
+if ( ! empty( $dlm_attributes['className'] ) ) {
+	$attributes['link_attributes']['class'][] = $dlm_attributes['className'];
+}
+
+// Get the required membership levels and override the link.
+$download_membership_levels = pmprodlm_getDownloadLevels( $dlm_download );
+if ( count( $download_membership_levels[0] ) > 1 || empty( $download_membership_levels[0][0] ) ) {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'levels' ) );
+} else {
+	$attributes['link_attributes']['href'] = esc_url( pmpro_url( 'checkout', '?level=' . $download_membership_levels[0][0], 'https' ) );
+}
+unset( $attributes['link_attributes']['rel'] );
+
+/**
+ * Hook: dlm_template_content_before_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_before_link', $dlm_download, $attributes, $template );
+?>
+<a <?php echo DLM_Utils::generate_attributes( $attributes['link_attributes'] ); // phpcs:ignore WordPress.Security.EscapeOutput ?>>
+	<?php $dlm_download->the_title(); ?>
+</a>
+(<?php
+	echo esc_html__( 'Membership Required', 'pmpro-download-monitor' );
+	if ( ! empty( $download_membership_levels[1] ) ) {
+		echo ': ' . esc_html( $download_membership_levels[1] );
+	}
+?>)
+<?php
+
+/**
+ * Hook: dlm_template_content_after_link.
+ *
+ * @param DLM_Download $dlm_download The download object.
+ * @param array        $attributes   The template attributes.
+ * @param string       $template     The template file.
+ *
+ * @since 4.9.6
+ */
+do_action( 'dlm_template_content_after_link', $dlm_download, $attributes, $template );
+?>


### PR DESCRIPTION
## Summary
- **Fixes #3**: Download Monitor Gutenberg block now filters output for membership requirements, showing restricted templates instead of download links for non-members.
- Restructures `pmprodlm_dlm_get_template_part` to check membership access first, routing to style-matched restricted templates (button, box, title, filename, default) or returning DLM's default template unchanged.
- Simplifies all 5 PMPro templates to restricted-state only, removing duplicated has-access branches that forked DLM's templates. Templates updated to DLM v4.9.6 patterns (DLM_Utils attributes, Gutenberg className support, before/after link hooks, proper escaping and text domains).
- Removes redundant `pmprodlm_shortcode_download_content` shortcode hijack and `pmprodlm_get_download` helper — the template filter now handles blocks and shortcodes uniformly.
- Scopes template filter to `content-download` slug only, preventing interference with DLM's no-access, terms & conditions, or other template types.
- Adds `_doing_it_wrong` notice for direct use of internal `pmpro_*` template names in shortcode/block attributes.
- Simplifies CPT registration to always use `pmpro_restrictable_post_types` filter.
- Updates readme.txt to remove documentation of `pmpro_*` template names and `pmprodlm_shortcode_download_content_filter`.

## Test plan
- [ ] Place a Download Monitor block on a page with a membership-restricted download. View as non-member — should see "Membership Required" with checkout/levels link.
- [ ] View same page as a member with access — should see normal DLM download button.
- [ ] Test `[download id="X"]` shortcode (no template) as non-member — restricted default template.
- [ ] Test `[download id="X" template="box"]` as non-member — restricted box template.
- [ ] Test `[download id="X" template="button"]` as non-member — restricted button template with styled output.
- [ ] Test legacy `[download id="X" template="pmpro_box"]` — should trigger `_doing_it_wrong` notice in debug mode.
- [ ] Verify direct download URL access by non-member is still blocked by `dlm_can_download` filter.
- [ ] Verify DLM no-access page and modal functionality are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
